### PR TITLE
MAINT: Updating CI Configurations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,40 +15,31 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8]
-
     env:
       FC: gfortran-9
+      F90: gfortran-9
       CC: gcc-9
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Cache original source files
-      uses: actions/cache@v1
-      with:
-        path: msis2
-        key: tar-cache-${{ hashFiles('**/*.F90') }}
-        restore-keys: |
-          tar-cache-
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Download source files
+      run: |
+        python .github/workflows/download_mirror.py
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install -r requirements.txt
         pip install .
-
-    - name: Investigate output after install
-      run: |
-        pwd
-        ls -lh
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/download_mirror.py
+++ b/.github/workflows/download_mirror.py
@@ -1,0 +1,12 @@
+"""This is only for CI downloading/testing."""
+import tarfile
+import urllib.request
+
+SOURCE_FILE = ("https://gist.github.com/greglucas/"
+               "6a545a4ccbfdb93290a96ad13a0b6f81/"
+               "raw/8a853f3e1c2b324f1c4ea9e0fa1e6d073258a456/"
+               "NRLMSIS2.0.tar.gz")
+
+with urllib.request.urlopen(SOURCE_FILE) as stream:
+    tf = tarfile.open(fileobj=stream, mode="r|gz")
+    tf.extractall(path='msis2/')


### PR DESCRIPTION
GitHub Actions are failing downloading the file, but works on my local machine.
Testing out what requirements need to be put in.

It looks to be some DNS server routing issue? I ended up creating a mirror to the data instead and downloading the files as a new action. This doesn't change the default install grabbing from NRL still.