### PR TITLE
Switch to setuptools rather than numpy distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@
 """The setup script."""
 import os
 import sys
-from setuptools import Extension, setup
+import setuptools
+from numpy.distutils.core import Extension, setup
 
 # Some system's don't include the local directory on the
 # base Python path for some reason, so add it in directly

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 """The setup script."""
 import os
 import sys
-from numpy.distutils.core import Extension, setup
+from setuptools import Extension, setup
 
 # Some system's don't include the local directory on the
 # base Python path for some reason, so add it in directly


### PR DESCRIPTION
Hey guys, 

Thank you for the great MSIS wrapper :)
I found out recently that if one try to `pip install pymsis` on a fresh install of python 3.10.6 (only with `pip==22.1.2`, `setuptools==63.2.0`, `wheel==0.37.1`), it installs `numpy` first and then proceeds to installing `pymsis` itself.
However, when I put `pymsis` as part of a `requirements.txt` for a package of mine, and try to `pip install` my package on a fresh install of python 3.10.6, it fails because `pymsis/setup.py` is trying to do `from numpy.distutils.core import Extension, setup` before anything else but cannot find `numpy`.

I suggest using `setuptools` instead of `numpy.distutils.core` to walk around this issue and allow install of `pymsis` as part of a set of requirements even on the freshest of python install.