### PR TITLE
MNT/FIX: Update wrappers with proper argument order

### DIFF
--- a/src/wrappers/msis00.pyf
+++ b/src/wrappers/msis00.pyf
@@ -6,14 +6,14 @@ python module msis00f ! in
         subroutine pytselec(switch_legacy) ! in :pymsis2:pymsis00.F90
             real(kind=4), optional,dimension(25),intent(in) :: switch_legacy
         end subroutine pyinitswitch
-        subroutine pygtd7d(day,utsec,z,lat,lon,sfluxavg,sflux,ap,output,n) ! in :pymsis:pymsis00.F90
+        subroutine pygtd7d(day,utsec,lon,lat,z,sflux,sfluxavg,ap,output,n) ! in :pymsis:pymsis00.F90
             real dimension(n),intent(in) :: day
             real dimension(n),intent(in),depend(n) :: utsec
-            real dimension(n),intent(in),depend(n) :: z
-            real dimension(n),intent(in),depend(n) :: lat
             real dimension(n),intent(in),depend(n) :: lon
-            real dimension(n),intent(in),depend(n) :: sfluxavg
+            real dimension(n),intent(in),depend(n) :: lat
+            real dimension(n),intent(in),depend(n) :: z
             real dimension(n),intent(in),depend(n) :: sflux
+            real dimension(n),intent(in),depend(n) :: sfluxavg
             real dimension(n,7),intent(in),depend(n) :: ap
             real dimension(n,11),intent(out),depend(n) :: output
             integer, optional,intent(in),check(len(day)>=n),depend(day) :: n=len(day)

--- a/src/wrappers/msis20.pyf
+++ b/src/wrappers/msis20.pyf
@@ -8,16 +8,16 @@ python module msis20f ! in
             real(kind=4), optional,dimension(25),intent(in) :: switch_legacy
             character(len=*), intent(in), optional    :: parmpath
         end subroutine pyinitswitch
-        subroutine pymsiscalc(day,utsec,z,lat,lon,sfluxavg,sflux,ap,output,n) ! in :pymsis:msis2.F90
+        subroutine pymsiscalc(day,utsec,lon,lat,z,sfluxavg,sflux,ap,output,n) ! in :pymsis:msis2.F90
             use msis_calc, only: msiscalc
             use msis_constants, only: rp
             real(kind=rp) dimension(n),intent(in) :: day
             real(kind=rp) dimension(n),intent(in),depend(n) :: utsec
-            real(kind=rp) dimension(n),intent(in),depend(n) :: z
-            real(kind=rp) dimension(n),intent(in),depend(n) :: lat
             real(kind=rp) dimension(n),intent(in),depend(n) :: lon
-            real(kind=rp) dimension(n),intent(in),depend(n) :: sfluxavg
+            real(kind=rp) dimension(n),intent(in),depend(n) :: lat
+            real(kind=rp) dimension(n),intent(in),depend(n) :: z
             real(kind=rp) dimension(n),intent(in),depend(n) :: sflux
+            real(kind=rp) dimension(n),intent(in),depend(n) :: sfluxavg
             real(kind=rp) dimension(n,7),intent(in),depend(n) :: ap
             real(kind=rp) dimension(n,11),intent(out),depend(n) :: output
             integer, optional,intent(in),check(len(day)>=n),depend(day) :: n=len(day)

--- a/src/wrappers/msis21.pyf
+++ b/src/wrappers/msis21.pyf
@@ -8,16 +8,16 @@ python module msis21f ! in
             real(kind=4), optional,dimension(25),intent(in) :: switch_legacy
             character(len=*), intent(in), optional    :: parmpath
         end subroutine pyinitswitch
-        subroutine pymsiscalc(day,utsec,z,lat,lon,sfluxavg,sflux,ap,output,n) ! in :pymsis:msis2.F90
+        subroutine pymsiscalc(day,utsec,lon,lat,z,sflux,sfluxavg,ap,output,n) ! in :pymsis:msis2.F90
             use msis_calc, only: msiscalc
             use msis_constants, only: rp
             real(kind=rp) dimension(n),intent(in) :: day
             real(kind=rp) dimension(n),intent(in),depend(n) :: utsec
-            real(kind=rp) dimension(n),intent(in),depend(n) :: z
-            real(kind=rp) dimension(n),intent(in),depend(n) :: lat
             real(kind=rp) dimension(n),intent(in),depend(n) :: lon
-            real(kind=rp) dimension(n),intent(in),depend(n) :: sfluxavg
+            real(kind=rp) dimension(n),intent(in),depend(n) :: lat
+            real(kind=rp) dimension(n),intent(in),depend(n) :: z
             real(kind=rp) dimension(n),intent(in),depend(n) :: sflux
+            real(kind=rp) dimension(n),intent(in),depend(n) :: sfluxavg
             real(kind=rp) dimension(n,7),intent(in),depend(n) :: ap
             real(kind=rp) dimension(n,11),intent(out),depend(n) :: output
             integer, optional,intent(in),check(len(day)>=n),depend(day) :: n=len(day)


### PR DESCRIPTION
The Python side expects `(date, lon, lat, z)`, which is what the Fortran subroutines is defined as, but the wrapper interface defintion had `lon`/`z` swapped (corresponding to the actual Fortran implementation).

This doesn't affect any results since the interface uses the argument order as inputs and they were all the same type and defined properly in the actual subroutine implementation.

closes #24