### PR TITLE
Python 3.12 updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2019, ubuntu-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     defaults:
       run:
         shell: bash

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,17 +11,37 @@ on:
     branches:
       - 'main'
   release:
+  # Also allow running this action on PRs if requested by applying the
+  # "Run cibuildwheel" label.
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
 
 jobs:
   generate-wheels-matrix:
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'release' ||
+      (github.event_name == 'pull_request' && (
+        (
+          github.event.action == 'labeled' &&
+          github.event.label.name == 'CI: build wheels'
+        ) ||
+        contains(github.event.pull_request.labels.*.name,
+                'CI: build wheels')
+      )
+      )
     name: Generate wheels matrix
     runs-on: ubuntu-latest
     outputs:
       include: ${{ steps.set-matrix.outputs.include }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install cibuildwheel
-        run: pipx install cibuildwheel==2.12.0
+        run: pipx install cibuildwheel==2.16.1
       - id: set-matrix
         run: |
           MATRIX=$(
@@ -36,10 +56,10 @@ jobs:
           )
           echo "include=$MATRIX" >> $GITHUB_OUTPUT          
         env:
-          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-*"
-          # Skip 32 bit windows builds due to compiler
-          # Skip musllinux because there aren't musllinux wheels yet
-          CIBW_SKIP: "*-win32 *-musllinux*"
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
+          # skip 32 bit windows and linux builds because numpy
+          # does not provide wheels for these platforms
+          CIBW_SKIP: "*-win32 *_i686"
           # TODO: Look into universal2 support, but compilers and options
           #       will be tricky with the Fortran code and tests...
           CIBW_ARCHS_MACOS: x86_64
@@ -54,7 +74,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
@@ -85,13 +105,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Download source files
         run: |
           python .github/workflows/download_mirror.py
 
-      - uses: pypa/cibuildwheel@v2.12.0
+      - uses: pypa/cibuildwheel@v2.16.1
         with:
           only: ${{ matrix.only }}
 
@@ -103,12 +123,12 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Download source files
         run: |

--- a/pymsis/msis.py
+++ b/pymsis/msis.py
@@ -1,6 +1,6 @@
 """Interface for running and creating input for the MSIS models."""
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -18,7 +18,7 @@ def run(
     f107as: Optional[npt.ArrayLike] = None,
     aps: Optional[npt.ArrayLike] = None,
     *,
-    options: Optional[List[float]] = None,
+    options: Optional[list[float]] = None,
     version: Union[float, str] = 2.1,
     **kwargs: dict,
 ) -> npt.NDArray:
@@ -198,7 +198,7 @@ def create_options(
     mixed_ut_long: float = 1,
     mixed_ap_ut_long: float = 1,
     terdiurnal: float = 1,
-) -> List[float]:
+) -> list[float]:
     """
     Create the options list based on keyword argument choices.
 
@@ -268,7 +268,7 @@ def create_input(
     f107s: Optional[npt.ArrayLike] = None,
     f107as: Optional[npt.ArrayLike] = None,
     aps: Optional[npt.ArrayLike] = None,
-) -> Tuple[Tuple, npt.NDArray]:
+) -> tuple[tuple, npt.NDArray]:
     """
     Combine all input values into a single flattened array.
 

--- a/pymsis/utils.py
+++ b/pymsis/utils.py
@@ -3,7 +3,7 @@ import urllib.request
 import warnings
 from io import BytesIO
 from pathlib import Path
-from typing import Dict, Optional, Tuple
+from typing import Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -14,7 +14,7 @@ import pymsis
 _DATA_FNAME: str = "SW-All.csv"
 _F107_AP_URL: str = f"https://celestrak.org/SpaceData/{_DATA_FNAME}"
 _F107_AP_PATH: Path = Path(pymsis.__file__).parent / _DATA_FNAME
-_DATA: Optional[Dict[str, npt.NDArray]] = None
+_DATA: Optional[dict[str, npt.NDArray]] = None
 
 
 def download_f107_ap() -> None:
@@ -48,7 +48,7 @@ def download_f107_ap() -> None:
         f.write(req.read())
 
 
-def _load_f107_ap_data() -> Dict[str, npt.NDArray]:
+def _load_f107_ap_data() -> dict[str, npt.NDArray]:
     """Load data from disk, if it isn't present go out and download it first."""
     if not _F107_AP_PATH.exists():
         download_f107_ap()
@@ -160,7 +160,7 @@ def _load_f107_ap_data() -> Dict[str, npt.NDArray]:
     return data
 
 
-def get_f107_ap(dates: npt.ArrayLike) -> Tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
+def get_f107_ap(dates: npt.ArrayLike) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
     """
     Retrieve the F10.7 and ap data needed to run msis for the given times.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,7 @@
 build-backend = "mesonpy"
 requires = [
     "meson-python>=0.10.0",
-    "wheel",
-    "oldest-supported-numpy"
+    "numpy>=1.25",
 ]
 
 [project]
@@ -20,10 +19,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development",
     "Topic :: Scientific/Engineering",
     "Operating System :: Microsoft :: Windows",
@@ -31,12 +30,11 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = ["numpy"]
 
 [project.optional-dependencies]
 tests = [
-    "flake8",
     "pytest",
     "pytest-cov",
 ]


### PR DESCRIPTION
Adds Python 3.12 to the tests and wheel builds. No major changes to the library required, but dropping 3.8 support does allow us to drop some typing imports.