### PR TITLE
CI: Remove wheel building from pushes

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,11 +5,6 @@ concurrency:
 
 # Only build on tagged releases
 on:
-  push:
-    tags:
-      - '*'
-    branches:
-      - 'main'
   release:
   # Also allow running this action on PRs if requested by applying the
   # "Run cibuildwheel" label.
@@ -23,7 +18,6 @@ on:
 jobs:
   generate-wheels-matrix:
     if: |
-      github.event_name == 'push' ||
       github.event_name == 'release' ||
       (github.event_name == 'pull_request' && (
         (


### PR DESCRIPTION
Previously this would trigger lots of jobs and would cancel the "release" one which would upload to PyPI, so we weren't getting uploads to PyPI unfortunately. We can make sure that we only do labeled PRs and releases, but only upload to PyPI on the release events.