### PR TITLE
BLD: Require numpy 2.0 for building now

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,12 +2,10 @@ project(
   'pymsis',
   'c',
   # Note that the git commit hash cannot be added dynamically here
-  version: '0.6.0',
+  version: '0.9.0',
   license: 'MIT',
-  meson_version: '>= 0.64.0',
+  meson_version: '>=1.2.99',
   default_options: [
-    'buildtype=debugoptimized',
-    'c_std=c99',
     'fortran_std=legacy',
   ],
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,12 +2,12 @@
 build-backend = "mesonpy"
 requires = [
     "meson-python>=0.10.0",
-    "numpy>=1.25",
+    "numpy>=2.0.0rc1",
 ]
 
 [project]
 name = "pymsis"
-version = "0.8.0"
+version = "0.9.0"
 description = "A Python wrapper around the NRLMSIS model."
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
This will still work with older versions of numpy, but builds wheels that can be used in either version.