### PR TITLE
CI: Update workflow concurrency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,14 +2,15 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: tests
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
-  cancel-in-progress: true
 
 on:
   push:
     branches: [ 'main' ]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  cancel-in-progress: true
 
 jobs:
   linting:
@@ -27,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2019, ubuntu-latest, macos-latest, macos-14]
+        os: [windows-latest, ubuntu-latest, macos-latest, macos-14]
         python-version: ['3.10', '3.11', '3.12']
     defaults:
       run:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,11 +1,9 @@
 name: Build wheels
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
-  cancel-in-progress: true
 
 # Only build on tagged releases
 on:
   release:
+    types: [published]
   # Also allow running this action on PRs if requested by applying the
   # "Run cibuildwheel" label.
   pull_request:
@@ -14,6 +12,10 @@ on:
       - synchronize
       - reopened
       - labeled
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event_name }}-${{ github.event.ref }}
+  cancel-in-progress: true
 
 jobs:
   build_wheels:


### PR DESCRIPTION
Add "event_name" to the concurrency group to try and spread out the groups based on "release" and "pull_request" separately. Ideally the "pull_request" group won't cancel the "release" workflow.

Update test runner to windows-latest.