### PR TITLE
FIX: Handle updating options without changing other variables

### DIFF
--- a/pymsis/msis.py
+++ b/pymsis/msis.py
@@ -9,6 +9,11 @@ from pymsis import msis00f, msis20f, msis21f  # type: ignore
 from pymsis.utils import get_f107_ap
 
 
+# Store the previous options to avoid reinitializing the model
+# each iteration unless necessary
+_previous_options: dict[str, list[float] | None] = {"0": None, "2.0": None, "2.1": None}
+
+
 def run(
     dates: npt.ArrayLike,
     lons: npt.ArrayLike,
@@ -135,7 +140,9 @@ def run(
     # convert to string version
     version = str(version)
     if version in {"0", "00"}:
-        msis00f.pytselec(options)
+        if _previous_options["0"] != options:
+            msis00f.pytselec(options)
+            _previous_options["0"] = options
         output = msis00f.pygtd7d(
             input_data[:, 0],
             input_data[:, 1],
@@ -154,10 +161,17 @@ def run(
 
         # Select the proper library. Default to version 2.1, unless explicitly
         # requested "2.0" via string
-        msis_lib = msis21f
         if version == "2.0":
             msis_lib = msis20f
-        msis_lib.pyinitswitch(options, parmpath=msis_path)
+        else:
+            version = "2.1"
+            msis_lib = msis21f
+
+        # Only reinitialize the model if the options have changed
+        if _previous_options[version] != options:
+            msis_lib.pyinitswitch(options, parmpath=msis_path)
+            _previous_options[version] = options
+
         output = msis_lib.pymsiscalc(
             input_data[:, 0],
             input_data[:, 1],

--- a/src/wrappers/msis2.F90
+++ b/src/wrappers/msis2.F90
@@ -1,13 +1,23 @@
 
 subroutine pyinitswitch(switch_legacy, parmpath)
+    use msis_calc, only: msiscalc
+    use msis_constants, only: rp
     use msis_init, only: msisinit
 
     implicit none
 
     real(4), intent(in), optional             :: switch_legacy(1:25)      !Legacy switch array
     character(len=*), intent(in), optional    :: parmpath                 !Path to parameter file
+    real(kind=rp)                             :: output = 0.
+    real(kind=rp)                             :: output_arr(1:11) = 0.
 
     call msisinit(switch_legacy=switch_legacy, parmpath=parmpath)
+
+    ! Artificially call msiscalc to reset the last variables as there is
+    ! a global cache on these and the parameters won't be updated if we
+    ! don't set them to something different.
+    ! See issue: gh-59
+    call msiscalc(0., 0., -999., -999., -1., 0., 0., (/1., 1., 1., 1., 1., 1., 1./), output, output_arr)
 
     return
 end subroutine pyinitswitch


### PR DESCRIPTION
There was an issue in MSIS2 where some steps are cached in the Fortran code if the input values (lat, lon, ...) are unchanged between subsequent runs. This causes issues if one wants to compare what the differences are between the options switches. (MSIS00 didn't have this same cache)

Additionally, add a check to the Python side to only call the init() function when options have changed, not every time we enter the run() call.

closes #59 