### PR TITLE
Add multi-threaded support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,11 @@ jobs:
     - name: Install pymsis
       run: |
         python -m pip install --upgrade pip
-        pip install -v .[tests]
+        # TODO: Remove meson installation from source once a new release
+        # that includes https://github.com/mesonbuild/meson/pull/13851 is available
+        python -m pip install git+https://github.com/mesonbuild/meson
+        python -m pip install ninja meson-python setuptools_scm numpy
+        python -m pip install --no-build-isolation -v .[tests]
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest, macos-14]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.13t']
     defaults:
       run:
         shell: bash
@@ -61,7 +61,7 @@ jobs:
         echo "PYTHONUTF8=1" >> $GITHUB_ENV
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: Quansight-Labs/setup-python@b9ab292c751a42bcd2bb465b7fa202ea2c3f5796  # v5.3.1
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -40,6 +40,8 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Download source files
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -82,6 +82,12 @@ jobs:
           # from source rather than use setup-fortran if we want to support
           # lower macOS versions.
           MACOSX_DEPLOYMENT_TARGET: "${{ matrix.os == 'macos-13' && '13.0' || '14.0' }}"
+          # TEMP don't use automated/isolated build environment, but manually
+          # install build dependencies so we can build with meson from source
+          CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
+          CIBW_BEFORE_BUILD:
+            python -m pip install git+https://github.com/mesonbuild/meson &&
+            python -m pip install ninja meson-python setuptools_scm numpy
 
       - uses: actions/upload-artifact@v4
         with:

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'pymsis',
   'c',
   # Note that the git commit hash cannot be added dynamically here
-  version: run_command(find_program('python3'), '-m', 'setuptools_scm', check: true).stdout().strip(),
+  version: run_command('python', '-m', 'setuptools_scm', check: true).stdout().strip(),
   license: 'MIT',
   meson_version: '>=1.2.99',
   default_options: [

--- a/pymsis/msis.py
+++ b/pymsis/msis.py
@@ -1,5 +1,6 @@
 """Interface for running and creating input for the MSIS models."""
 
+import threading
 from pathlib import Path
 
 import numpy as np
@@ -9,11 +10,13 @@ from pymsis import msis00f, msis20f, msis21f  # type: ignore
 from pymsis.utils import get_f107_ap
 
 
-# Store the previous options to avoid reinitializing the model
-# each iteration unless necessary
-msis00f._last_used_options = None
-msis20f._last_used_options = None
-msis21f._last_used_options = None
+for lib in [msis00f, msis20f, msis21f]:
+    # Store the previous options to avoid reinitializing the model
+    # each iteration unless necessary
+    lib._last_used_options = None
+    # Anytime we call into the Fortran code, we need to lock
+    # to avoid threading issues
+    lib._lock = threading.Lock()
 
 
 def run(
@@ -142,19 +145,20 @@ def run(
     # convert to string version
     version = str(version)
     if version in {"0", "00"}:
-        if msis00f._last_used_options != options:
-            msis00f.pytselec(options)
-            msis00f._last_used_options = options
-        output = msis00f.pygtd7d(
-            input_data[:, 0],
-            input_data[:, 1],
-            input_data[:, 2],
-            input_data[:, 3],
-            input_data[:, 4],
-            input_data[:, 5],
-            input_data[:, 6],
-            input_data[:, 7:],
-        )
+        with msis00f._lock:
+            if msis00f._last_used_options != options:
+                msis00f.pytselec(options)
+                msis00f._last_used_options = options
+            output = msis00f.pygtd7d(
+                input_data[:, 0],
+                input_data[:, 1],
+                input_data[:, 2],
+                input_data[:, 3],
+                input_data[:, 4],
+                input_data[:, 5],
+                input_data[:, 6],
+                input_data[:, 7:],
+            )
 
     elif version.startswith("2"):
         # We need to point to the MSIS parameter file that was installed with
@@ -169,21 +173,22 @@ def run(
             version = "2.1"
             msis_lib = msis21f
 
-        # Only reinitialize the model if the options have changed
-        if msis_lib._last_used_options != options:
-            msis_lib.pyinitswitch(options, parmpath=msis_path)
-            msis_lib._last_used_options = options
+        with msis_lib._lock:
+            # Only reinitialize the model if the options have changed
+            if msis_lib._last_used_options != options:
+                msis_lib.pyinitswitch(options, parmpath=msis_path)
+                msis_lib._last_used_options = options
 
-        output = msis_lib.pymsiscalc(
-            input_data[:, 0],
-            input_data[:, 1],
-            input_data[:, 2],
-            input_data[:, 3],
-            input_data[:, 4],
-            input_data[:, 5],
-            input_data[:, 6],
-            input_data[:, 7:],
-        )
+            output = msis_lib.pymsiscalc(
+                input_data[:, 0],
+                input_data[:, 1],
+                input_data[:, 2],
+                input_data[:, 3],
+                input_data[:, 4],
+                input_data[:, 5],
+                input_data[:, 6],
+                input_data[:, 7:],
+            )
 
     else:
         raise ValueError(

--- a/pymsis/msis.py
+++ b/pymsis/msis.py
@@ -11,7 +11,9 @@ from pymsis.utils import get_f107_ap
 
 # Store the previous options to avoid reinitializing the model
 # each iteration unless necessary
-_previous_options: dict[str, list[float] | None] = {"0": None, "2.0": None, "2.1": None}
+msis00f._last_used_options = None
+msis20f._last_used_options = None
+msis21f._last_used_options = None
 
 
 def run(
@@ -140,9 +142,9 @@ def run(
     # convert to string version
     version = str(version)
     if version in {"0", "00"}:
-        if _previous_options["0"] != options:
+        if msis00f._last_used_options != options:
             msis00f.pytselec(options)
-            _previous_options["0"] = options
+            msis00f._last_used_options = options
         output = msis00f.pygtd7d(
             input_data[:, 0],
             input_data[:, 1],
@@ -168,9 +170,9 @@ def run(
             msis_lib = msis21f
 
         # Only reinitialize the model if the options have changed
-        if _previous_options[version] != options:
+        if msis_lib._last_used_options != options:
             msis_lib.pyinitswitch(options, parmpath=msis_path)
-            _previous_options[version] = options
+            msis_lib._last_used_options = options
 
         output = msis_lib.pymsiscalc(
             input_data[:, 0],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ addopts = [
 build = "cp310-* cp311-* cp312-* cp313-*"
 # skip 32 bit windows and linux builds for lack of numpy wheels
 skip = "*-win32 *_i686"
+free-threaded-support = true
 test-requires = "pytest"
 test-command = "pytest --pyargs pymsis"
 

--- a/tests/test_msis.py
+++ b/tests/test_msis.py
@@ -462,8 +462,8 @@ def test_options_calls(input_data):
     # Check that we don't call the initialization function unless
     # our options have changed between calls.
     # Reset the cache
-    for version in msis._previous_options:
-        msis._previous_options[version] = None
+    for msis_lib in [msis00f, msis20f, msis21f]:
+        msis_lib._last_used_options = None
     with patch("pymsis.msis21f.pyinitswitch") as mock_init:
         msis.run(*input_data, options=[0] * 25)
         mock_init.assert_called_once()

--- a/tools/generate_f2pymod.py
+++ b/tools/generate_f2pymod.py
@@ -28,6 +28,7 @@ def main():
                 args.infile,
                 "--build-dir",
                 outdir_abs,
+                "--freethreading-compatible",
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,


### PR DESCRIPTION
This adds some locks around the calls to make sure we are only entering the Fortran routines from a single thread at a time. This prevents the Fortran global state from being modified while another thread is trying to run its calculations.

The extension module is still not technically threadsafe, but we are claiming that our library is when entering from the Python side where the locks are implemented. The added test fails on standard Python builds as well, so we have always had issues with threading previously.