### PR TITLE
PERF: avoid stacking in input creation and isclose comparisons

### DIFF
--- a/pymsis/msis.py
+++ b/pymsis/msis.py
@@ -190,9 +190,8 @@ def run(
         )
 
     # The Fortran code puts 9.9e-38 in as NaN
-    # Have to make sure this doesn't overlap 0 due to really small values
-    # so atol should be less than the comparison value
-    output[np.isclose(output, 9.9e-38, atol=1e-38)] = np.nan
+    # or 9.99e-38, or 9.999e-38, so lets just bound the 9s
+    output[(output >= 9.9e-38) & (output < 1e-37)] = np.nan  # noqa: PLR2004
 
     return output.reshape(*input_shape, 11)
 


### PR DESCRIPTION
We can replace these with inline versions ourself that speeds up our initial array creations and gets them into the Fortran ordering that f2py wants to pass by reference as well.