### PR TITLE
MNT: Avoid overwriting user's longitude values

### DIFF
--- a/pymsis/msis.py
+++ b/pymsis/msis.py
@@ -326,9 +326,6 @@ def create_input(
     #       regression tests indicate it should still be integer DOY
     # dyear += dseconds/86400
     lons = np.atleast_1d(lons)
-    # If any longitudes were input as negatives, try to change them to
-    # the (0, 360) range
-    lons[lons < 0] += 360
     lats = np.atleast_1d(lats)
     alts = np.atleast_1d(alts)
 

--- a/src/wrappers/msis00.F90
+++ b/src/wrappers/msis00.F90
@@ -25,11 +25,16 @@
       real, intent(out) :: output(n, 1:11)
 
       integer :: i
-      real :: t(2), d(9) ! Temporary to swap dimensions
+      real :: t(2), d(9), lon_tmp ! Temporary to swap dimensions
 
       do i=1, n
-        call gtd7d(10000 + FLOOR(day(i)), utsec(i), z(i), lat(i), lon(i), &
-                   utsec(i)/3600. + lon(i)/15., sfluxavg(i), &
+        if (lon(i) < 0) then
+          lon_tmp = lon(i) + 360
+        else
+          lon_tmp = lon(i)
+        endif
+        call gtd7d(10000 + FLOOR(day(i)), utsec(i), z(i), lat(i), lon_tmp, &
+                   utsec(i)/3600. + lon_tmp/15., sfluxavg(i), &
                    sflux(i), ap(i, :), 48, d, t)
         ! O, H, and N are set to zero below 72.5 km
         ! Change them to NaN instead

--- a/src/wrappers/msis2.F90
+++ b/src/wrappers/msis2.F90
@@ -43,8 +43,14 @@ subroutine pymsiscalc(day, utsec, lon, lat, z, sflux, sfluxavg, ap, output, n)
     real(kind=rp), intent(out) :: output(n, 1:11)
 
     integer :: i
+    real(kind=rp) :: lon_tmp
 
     do i=1, n
+        if (lon(i) < 0) then
+            lon_tmp = lon(i) + 360
+          else
+            lon_tmp = lon(i)
+          endif
         call msiscalc(day(i), utsec(i), z(i), lat(i), lon(i), sfluxavg(i), &
                     sflux(i), ap(i, :), output(i, 11), output(i, 1:10))
     enddo


### PR DESCRIPTION
We currently wrote the longitude wrapping into the Python code, but that updates the longitudes inplace. We can avoid that by pushing that logic into the Fortran wrappers easily enough and should be more performant too.