### PR TITLE
MNT: Refactor extension modules to use the same function names

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,15 +51,6 @@ jobs:
         which gfortran
         gfortran --version
 
-    # On Windows, the compilers can cause issues when
-    # using higher optimization levels
-    - name: Add Windows environment settings
-      if: startsWith(matrix.os, 'windows')
-      run: |
-        echo "FFLAGS=-O1" >> $GITHUB_ENV
-        # Windows can't decode the README which has utf8 characters
-        echo "PYTHONUTF8=1" >> $GITHUB_ENV
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: Quansight-Labs/setup-python@b9ab292c751a42bcd2bb465b7fa202ea2c3f5796  # v5.3.1
       with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -67,15 +67,6 @@ jobs:
           which gfortran
           gfortran --version
 
-      # On Windows, the compilers can cause issues when
-      # using higher optimization levels
-      - name: Add Windows environment settings
-        if: runner.os == 'Windows'
-        run: |
-          echo "FFLAGS=-O1" >> $GITHUB_ENV
-          # Windows can't decode the README which has utf8 characters
-          echo "PYTHONUTF8=1" >> $GITHUB_ENV
-
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.3
         env:

--- a/meson.build
+++ b/meson.build
@@ -31,6 +31,10 @@ if ff.has_argument('-Wno-conversion')
   add_project_arguments('-Wno-conversion', language: 'fortran')
 endif
 
+# Default to optimization level 1
+# Some CI jobs fail with higher levels of optimization, so restrict this by default.
+add_project_arguments('-O1', language: 'fortran')
+
 is_windows = host_machine.system() == 'windows'
 # Platform detection
 is_mingw = is_windows and cc.get_id() == 'gcc'

--- a/src/wrappers/msis00.F90
+++ b/src/wrappers/msis00.F90
@@ -1,37 +1,38 @@
-      subroutine pytselec(switch_legacy)
-      implicit none
+subroutine pyinitswitch(switch_legacy, parmpath)
+    implicit none
 
-      real(4), intent(in), optional             :: switch_legacy(1:25)      !Legacy switch array
+    real(4), intent(in), optional             :: switch_legacy(1:25)      !Legacy switch array
+    ! Here for compatibility with MSIS2 even though it is unused
+    character(len=*), intent(in), optional    :: parmpath                 !Path to parameter file
 
-      call tselec(switch_legacy)
-      call meters(.TRUE.)
+    call tselec(switch_legacy)
+    call meters(.TRUE.)
 
-      return
-      end subroutine pytselec
+    return
+end subroutine pyinitswitch
 
-      subroutine pygtd7d(day, utsec, lon, lat, z, sflux, sfluxavg, ap, output, n)
+subroutine pymsiscalc(day, utsec, lon, lat, z, sflux, sfluxavg, ap, output, n)
+    implicit none
 
-      implicit none
+    integer, intent(in)        :: n
+    real, intent(in)  :: day(n)
+    real, intent(in)  :: utsec(n)
+    real, intent(in)  :: lon(n)
+    real, intent(in)  :: lat(n)
+    real, intent(in)  :: z(n)
+    real, intent(in)  :: sflux(n)
+    real, intent(in)  :: sfluxavg(n)
+    real, intent(in)  :: ap(n, 1:7)
+    real, intent(out) :: output(n, 1:11)
 
-      integer, intent(in)        :: n
-      real, intent(in)  :: day(n)
-      real, intent(in)  :: utsec(n)
-      real, intent(in)  :: lon(n)
-      real, intent(in)  :: lat(n)
-      real, intent(in)  :: z(n)
-      real, intent(in)  :: sflux(n)
-      real, intent(in)  :: sfluxavg(n)
-      real, intent(in)  :: ap(n, 1:7)
-      real, intent(out) :: output(n, 1:11)
+    integer :: i
+    real :: t(2), d(9), lon_tmp ! Temporary to swap dimensions
 
-      integer :: i
-      real :: t(2), d(9), lon_tmp ! Temporary to swap dimensions
-
-      do i=1, n
+    do i=1, n
         if (lon(i) < 0) then
-          lon_tmp = lon(i) + 360
+            lon_tmp = lon(i) + 360
         else
-          lon_tmp = lon(i)
+            lon_tmp = lon(i)
         endif
         call gtd7d(10000 + FLOOR(day(i)), utsec(i), z(i), lat(i), lon_tmp, &
                    utsec(i)/3600. + lon_tmp/15., sfluxavg(i), &
@@ -39,12 +40,11 @@
         ! O, H, and N are set to zero below 72.5 km
         ! Change them to NaN instead
         if(z(i) < 72.5) then
-          d(2) = 9.99e-38 ! NaN
-          d(7) = 9.99e-38 ! NaN
-          d(8) = 9.99e-38 ! NaN
+            d(2) = 9.99e-38 ! NaN
+            d(7) = 9.99e-38 ! NaN
+            d(8) = 9.99e-38 ! NaN
         endif
         ! These mappings are to go from MSIS00 locations to MSIS2 locations
-                   
         output(i, 1) = d(6)
         output(i, 2) = d(3)
         output(i, 3) = d(4)
@@ -56,7 +56,73 @@
         output(i, 9) = d(9)
         output(i, 10) = 9.99e-38 ! NaN
         output(i, 11) = t(2)
-      enddo
+    enddo
 
-      return
-      end subroutine pygtd7d
+    return
+end subroutine pymsiscalc
+
+
+! Deprecated forms of the above functions
+subroutine pytselec(switch_legacy)
+  implicit none
+
+  real(4), intent(in), optional             :: switch_legacy(1:25)      !Legacy switch array
+
+  WRITE(6, *) 'Warning: pytselec is deprecated and will be removed in a future version. Use pyinitswitch instead.'
+  call tselec(switch_legacy)
+  call meters(.TRUE.)
+
+  return
+end subroutine pytselec
+
+subroutine pygtd7d(day, utsec, lon, lat, z, sflux, sfluxavg, ap, output, n)
+
+implicit none
+
+integer, intent(in)        :: n
+real, intent(in)  :: day(n)
+real, intent(in)  :: utsec(n)
+real, intent(in)  :: lon(n)
+real, intent(in)  :: lat(n)
+real, intent(in)  :: z(n)
+real, intent(in)  :: sflux(n)
+real, intent(in)  :: sfluxavg(n)
+real, intent(in)  :: ap(n, 1:7)
+real, intent(out) :: output(n, 1:11)
+
+integer :: i
+real :: t(2), d(9), lon_tmp ! Temporary to swap dimensions
+
+WRITE(6, *) 'Warning: pygtd7d is deprecated and will be removed in a future version. Use pymsiscalc instead.'
+do i=1, n
+  if (lon(i) < 0) then
+    lon_tmp = lon(i) + 360
+  else
+    lon_tmp = lon(i)
+  endif
+  call gtd7d(10000 + FLOOR(day(i)), utsec(i), z(i), lat(i), lon_tmp, &
+              utsec(i)/3600. + lon_tmp/15., sfluxavg(i), &
+              sflux(i), ap(i, :), 48, d, t)
+  ! O, H, and N are set to zero below 72.5 km
+  ! Change them to NaN instead
+  if(z(i) < 72.5) then
+    d(2) = 9.99e-38 ! NaN
+    d(7) = 9.99e-38 ! NaN
+    d(8) = 9.99e-38 ! NaN
+  endif
+  ! These mappings are to go from MSIS00 locations to MSIS2 locations
+  output(i, 1) = d(6)
+  output(i, 2) = d(3)
+  output(i, 3) = d(4)
+  output(i, 4) = d(2)
+  output(i, 5) = d(1)
+  output(i, 6) = d(7)
+  output(i, 7) = d(5)
+  output(i, 8) = d(8)
+  output(i, 9) = d(9)
+  output(i, 10) = 9.99e-38 ! NaN
+  output(i, 11) = t(2)
+enddo
+
+return
+end subroutine pygtd7d

--- a/src/wrappers/msis00.pyf
+++ b/src/wrappers/msis00.pyf
@@ -3,6 +3,23 @@
 
 python module msis00f ! in 
     interface  ! in :pymsis
+        subroutine pyinitswitch(switch_legacy, parmpath) ! in :pymsis2:pymsis00.F90
+            real(kind=4), optional,dimension(25),intent(in) :: switch_legacy
+            character(len=*), intent(in), optional          :: parmpath
+        end subroutine pyinitswitch
+        subroutine pymsiscalc(day,utsec,lon,lat,z,sflux,sfluxavg,ap,output,n) ! in :pymsis:pymsis00.F90
+            real dimension(n),intent(in) :: day
+            real dimension(n),intent(in),depend(n) :: utsec
+            real dimension(n),intent(in),depend(n) :: lon
+            real dimension(n),intent(in),depend(n) :: lat
+            real dimension(n),intent(in),depend(n) :: z
+            real dimension(n),intent(in),depend(n) :: sflux
+            real dimension(n),intent(in),depend(n) :: sfluxavg
+            real dimension(n,7),intent(in),depend(n) :: ap
+            real dimension(n,11),intent(out),depend(n) :: output
+            integer, optional,intent(in),check(len(day)>=n),depend(day) :: n=len(day)
+        end subroutine pygtd7d
+        ! The following functions are deprecated in 0.10 and will be removed in the future
         subroutine pytselec(switch_legacy) ! in :pymsis2:pymsis00.F90
             real(kind=4), optional,dimension(25),intent(in) :: switch_legacy
         end subroutine pyinitswitch


### PR DESCRIPTION
This updates the MSIS00 extension module to use the same call structure as MSIS2 so that we don't need to special case the method names in the calling functions. Adds a deprecation notice to the other signatures before removing them.