### PR TITLE
CI/REL: Update cibuildwheel to only use skips

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,9 @@ addopts = [
 ]
 
 [tool.cibuildwheel]
-build = "cp310-* cp311-* cp312-* cp313-*"
+# skip Python <3.10
 # skip 32 bit windows and linux builds for lack of numpy wheels
-skip = "*-win32 *_i686"
+skip = "cp36* cp37* cp38* cp39* *-win32 *_i686"
 free-threaded-support = true
 test-requires = "pytest"
 test-command = "pytest --pyargs pymsis"


### PR DESCRIPTION
We weren't building 313t wheels because we only had builds specified for 313-* not 313*. Switch the logic around and only remove builds instead which should also satisfy this identifier.