### PR TITLE
MNT/ENH: Export commonly used functions to the main namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [v0.10.0] 2024-11-19
 
+- **ADDED** Top-level function exports to avoid submodule imports
+  - `pymsis.calculate()` is the primrary entrypoint to running the MSIS
+    model and calculating the atmosphere at the requested data points.
+  - `pymsis.msis.run()` was not very descriptive and caused issues with IDL
+    bridging into Python and wanting that name reserved. To avoid this, the
+    function has been renamed `calculate` and is available as `pymsis.calculate()`
+    now. The `pymsis.msis.run()` is still available as an alias for now, but
+    may be removed in the future.
+- **ADDED** Variable enumeration for easier indexing into output arrays.
+  - This can be used as `pymsis.Variable.O2` for getting the `O2` species index.
+    For example, `output_array[..., pymsis.Variable.O2]`.
 - **ADDED** Python 3.13 and 3.13t support
 - **ADDED** Multithreaded support.
   - The underlying MSIS libraries are not threadsafe due
     to the use of many global/save variables. There is a lock around the
     extension modules so that only one thread will be calling the routines
     at a time, so the Python library is safe to use in a multi-threaded context.
-- **ADDED** Variable enumeration for easier indexing into output arrays.
-  - This can be used as `msis.Variable.O2` for getting the `O2` species index.
-    For example, `output_array[..., msis.Variable.O2]`.
 - **MAINTENANCE** Default `-O1` optimization level for all builds.
   - Previously, this
     was only done on Windows machines. Users can change this by updating
@@ -30,7 +38,7 @@ All notable changes to this project will be documented in this file.
 - **DEPRECATED** Calling `msis00f.pytselec()` and `msis00f.pygtd7d` functions.
   - Use `msis00f.pyinitswitch` and `msis00f.pymsiscalc` instead.
   - This helps with standardization across the extension modules. These extension
-    should rarely be used by external people and `msis.run()` is a better entry
+    should rarely be used by external people and `pymsis.calculate()` is a better entry
     to using the package.
 
 ## [v0.9.0] - 2024-04-03
@@ -57,7 +65,7 @@ All notable changes to this project will be documented in this file.
 ## [v0.6.0] - 2022-11-14
 
 - **ADDED** Automatic download of F10.7 and ap data for users.
-  - This means that F10.7 and ap are optional inputs to the `msis.run()`
+  - This means that F10.7 and ap are optional inputs to the `pymsis.calculate()`
     function during historical periods and the routines will automatically
     fetch the proper input data.
 
@@ -67,7 +75,7 @@ All notable changes to this project will be documented in this file.
 
 - **ADDED** MSIS2.1, a new version of MSIS.
   - This is the first version that contains NO.
-  - This is the new default used in `msis.run()`.
+  - This is the new default used in `pymsis.calculate()`.
 - **MAINTENANCE** Added more wheels to the release and CI systems for testing.
 
 ## [v0.4.0] - 2022-02-26

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ there is a web viewer that uses pymsis: <https://swx-trec.com/msis>
 
 ```python
 import numpy as np
-from pymsis import msis
+import pymsis
 
 dates = np.arange(np.datetime64("2003-10-28T00:00"), np.datetime64("2003-11-04T00:00"), np.timedelta64(30, "m"))
 # geomagnetic_activity=-1 is a storm-time run
-data = msis.run(dates, 0, 0, 400, geomagnetic_activity=-1)
+data = pymsis.calculate(dates, 0, 0, 400, geomagnetic_activity=-1)
 
 # Plot the data
 import matplotlib.pyplot as plt
@@ -56,7 +56,7 @@ is developed by the Naval Research Laboratory.
 Note that the MSIS2 code is not available for commercial use without
 contacting NRL. See the [MSIS2 license file](https://github.com/SWxTREC/pymsis/blob/main/MSIS2_LICENSE)) for explicit
 details. We do not repackage the MSIS source code in this
-repository for that reason. However, we do provide utilities to easily
+repository for that reason. However, utility functions are provided to easily
 download and extract the original source code. By using that code you
 agree to their terms and conditions.
 

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -5,30 +5,47 @@ API reference
 .. currentmodule:: pymsis
 
 This page gives an overview of the routines within the pymsis package.
-To run the code, use the :mod:`pymsis.msis` module.
-
-.. autosummary::
-    :toctree: generated/
-
-    msis.run
-    msis.create_options
-    msis.create_input
-
-The output of the model is stored in basic numpy arrays with the final
-dimension being the variable/species. To get the output in a more human-readable
-format, use the :class:`~.Variable` enumeration that provides
-easier indexing into the output arrays.
+To calculate atmospheric constituents at grid points, use the :func:`~.calculate` function.
+This is typically the only function you will need to use. You can access the output variables
+using the :class:`~.Variable` enumeration for easier indexing into the output data array.
+For example, as ``output_array[..., Variable.MASS_DENSITY]``.
 
 .. autosummary::
     :toctree: generated/
     :nosignatures:
 
-    msis.Variable
+    calculate
+    Variable
 
-To get input data for historical events, use the :mod:`pymsis.utils` module.
+msis module
+-----------
+
+For more control and help creating properly formatted inputs, one can
+use the :mod:`pymsis.msis` module. This module provides functions to
+create input data, create the options list, and run the model.
 
 .. autosummary::
     :toctree: generated/
+    :nosignatures:
+
+    msis.create_input
+    msis.create_options
+    msis.calculate
+
+utils module
+------------
+
+The MSIS model requires solar forcing data (F10.7 and ap) to calculate the state of the atmosphere.
+When running over past time periods, this data is automatically downloaded and used if not specified by the user.
+For more control over the F10.7 and Ap values the model is using, one can input the desired values
+into the :func:`~.calculate` call ``calculate(..., f107s=..., f107as=..., aps=...)``.
+To get the values used automatically by the model, the :mod:`pymsis.utils` module has several
+helper routines to download new files (will retrieve a file with data up to the present) and
+get the proper F10.7 and ap values to use for a specific date and time.
+
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
 
     utils.download_f107_ap
     utils.get_f107_ap

--- a/examples/plot_altitude_profiles.py
+++ b/examples/plot_altitude_profiles.py
@@ -12,7 +12,7 @@ and midnight (dashed).
 import matplotlib.pyplot as plt
 import numpy as np
 
-from pymsis import msis
+import pymsis
 
 
 lon = 0
@@ -24,9 +24,9 @@ ap = 7
 aps = [[ap] * 7]
 
 date = np.datetime64("2003-01-01T00:00")
-output_midnight = msis.run(date, lon, lat, alts, f107, f107a, aps)
+output_midnight = pymsis.calculate(date, lon, lat, alts, f107, f107a, aps)
 date = np.datetime64("2003-01-01T12:00")
-output_noon = msis.run(date, lon, lat, alts, f107, f107a, aps)
+output_noon = pymsis.calculate(date, lon, lat, alts, f107, f107a, aps)
 
 #  output is now of the shape (1, 1, 1, 1000, 11)
 # Get rid of the single dimensions
@@ -34,7 +34,7 @@ output_midnight = np.squeeze(output_midnight)
 output_noon = np.squeeze(output_noon)
 
 _, ax = plt.subplots()
-for variable in msis.Variable:
+for variable in pymsis.Variable:
     if variable.name in ("Total mass density", "Temperature"):
         # Ignore non-number densities
         continue

--- a/examples/plot_annual_variation.py
+++ b/examples/plot_annual_variation.py
@@ -10,7 +10,7 @@ difference from the annual mean at a single location.
 import matplotlib.pyplot as plt
 import numpy as np
 
-from pymsis import msis
+import pymsis
 
 
 lon = 0
@@ -27,7 +27,7 @@ f107s = [f107] * ndates
 f107as = [f107a] * ndates
 aps = [[ap] * 7] * ndates
 
-output = msis.run(dates, lon, lat, alt, f107s, f107as, aps)
+output = pymsis.calculate(dates, lon, lat, alt, f107s, f107as, aps)
 #  output is now of the shape (ndates, 1, 1, 1, 11)
 # Get rid of the single dimensions
 output = np.squeeze(output)
@@ -36,7 +36,7 @@ output = np.squeeze(output)
 variation = 100 * (output / output.mean(axis=0) - 1)
 
 _, ax = plt.subplots()
-for variable in msis.Variable:
+for variable in pymsis.Variable:
     if variable.name == "NO":
         # There is currently no NO data
         continue

--- a/examples/plot_diurnal_variation.py
+++ b/examples/plot_diurnal_variation.py
@@ -11,7 +11,7 @@ import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
 
-from pymsis import msis
+import pymsis
 
 
 lon = 0
@@ -28,7 +28,7 @@ f107s = [f107] * ndates
 f107as = [f107a] * ndates
 aps = [[ap] * 7] * ndates
 
-output = msis.run(dates, lon, lat, alt, f107s, f107as, aps)
+output = pymsis.calculate(dates, lon, lat, alt, f107s, f107as, aps)
 #  output is now of the shape (ndates, 1, 1, 1, 11)
 # Get rid of the single dimensions
 output = np.squeeze(output)
@@ -37,7 +37,7 @@ output = np.squeeze(output)
 variation = 100 * (output / output.mean(axis=0) - 1)
 
 _, ax = plt.subplots()
-for variable in msis.Variable:
+for variable in pymsis.Variable:
     ax.plot(dates, variation[:, variable], label=variable.name)
 
 ax.legend(

--- a/examples/plot_surface.py
+++ b/examples/plot_surface.py
@@ -10,7 +10,7 @@ quantities on a constant altitude plane.
 import matplotlib.pyplot as plt
 import numpy as np
 
-from pymsis import msis
+import pymsis
 
 
 lons = range(-180, 185, 5)
@@ -23,14 +23,14 @@ ap = 7
 date = np.datetime64("2003-01-01T12:00")
 aps = [[ap] * 7]
 
-output = msis.run(date, lons, lats, alt, f107, f107a, aps)
+output = pymsis.calculate(date, lons, lats, alt, f107, f107a, aps)
 #  output is now of the shape (1, nlons, nlats, 1, 11)
 # Get rid of the single dimensions
 output = np.squeeze(output)
 
 _, ax = plt.subplots()
 xx, yy = np.meshgrid(lons, lats)
-mesh = ax.pcolormesh(xx, yy, output[:, :, msis.Variable.O2].T, shading="auto")
+mesh = ax.pcolormesh(xx, yy, output[:, :, pymsis.Variable.O2].T, shading="auto")
 plt.colorbar(mesh, label="Number density (/m$^3$)")
 
 ax.set_title(f"O$_2$ number density at {alt} km")

--- a/examples/plot_surface_animation.py
+++ b/examples/plot_surface_animation.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.animation import FuncAnimation
 
-from pymsis import msis
+import pymsis
 
 
 lons = range(-180, 185, 5)
@@ -30,7 +30,7 @@ f107s = [f107] * ndates
 f107as = [f107a] * ndates
 aps = [[ap] * 7] * ndates
 
-output = msis.run(dates, lons, lats, alt, f107s, f107as, aps)
+output = pymsis.calculate(dates, lons, lats, alt, f107s, f107as, aps)
 #  output is now of the shape (ndates, nlons, nlats, 1, 11)
 # Get rid of the single dimensions
 output = np.squeeze(output)
@@ -42,14 +42,14 @@ xx, yy = np.meshgrid(lons, lats)
 vmin, vmax = 1e13, 8e13
 norm = matplotlib.colors.Normalize(vmin, vmax)
 mesh = ax_mesh.pcolormesh(
-    xx, yy, output[0, :, :, msis.Variable.N].T, shading="auto", norm=norm
+    xx, yy, output[0, :, :, pymsis.Variable.N].T, shading="auto", norm=norm
 )
 plt.colorbar(
     mesh, label=f"N number density at {alt} km (/m$^3$)", orientation="horizontal"
 )
 
 time_data = output[:, len(lons) // 2, len(lats) // 2, :]
-ax_time.plot(dates, time_data[:, msis.Variable.N], c="k")
+ax_time.plot(dates, time_data[:, pymsis.Variable.N], c="k")
 ax_time.set_xlim(dates[0], dates[-1])
 ax_time.set_ylim(vmin, vmax)
 ax_time.xaxis.set_major_locator(mdates.HourLocator(interval=3))
@@ -74,7 +74,7 @@ def update_surface(t):
     date_string = dates[t].astype("O").strftime("%H:%M")
     title.set_text(f"{date_string}")
     time_line.set_xdata([dates[t]])
-    mesh.set_array(output[t, :, :, msis.Variable.N].T)
+    mesh.set_array(output[t, :, :, pymsis.Variable.N].T)
     sun.set_data([sun_loc[t]], [0])
 
 

--- a/examples/plot_version_diff_altitude.py
+++ b/examples/plot_version_diff_altitude.py
@@ -12,7 +12,7 @@ and midnight (dashed).
 import matplotlib.pyplot as plt
 import numpy as np
 
-from pymsis import msis
+import pymsis
 
 
 lon = 0
@@ -24,13 +24,13 @@ ap = 7
 aps = [[ap] * 7]
 
 date = np.datetime64("2003-01-01T00:00")
-output_midnight2 = msis.run(date, lon, lat, alts, f107, f107a, aps)
-output_midnight0 = msis.run(date, lon, lat, alts, f107, f107a, aps, version=0)
+output_midnight2 = pymsis.calculate(date, lon, lat, alts, f107, f107a, aps)
+output_midnight0 = pymsis.calculate(date, lon, lat, alts, f107, f107a, aps, version=0)
 diff_midnight = (output_midnight2 - output_midnight0) / output_midnight0 * 100
 
 date = np.datetime64("2003-01-01T12:00")
-output_noon2 = msis.run(date, lon, lat, alts, f107, f107a, aps)
-output_noon0 = msis.run(date, lon, lat, alts, f107, f107a, aps, version=0)
+output_noon2 = pymsis.calculate(date, lon, lat, alts, f107, f107a, aps)
+output_noon0 = pymsis.calculate(date, lon, lat, alts, f107, f107a, aps, version=0)
 diff_noon = (output_noon2 - output_noon0) / output_noon0 * 100
 
 
@@ -40,7 +40,7 @@ diff_midnight = np.squeeze(diff_midnight)
 diff_noon = np.squeeze(diff_noon)
 
 _, ax = plt.subplots()
-for variable in msis.Variable:
+for variable in pymsis.Variable:
     if variable.name in ("NO", "Total mass density", "Temperature"):
         # There is currently no NO data for earlier versions,
         # also ignore non-number densities

--- a/examples/plot_version_diff_surface.py
+++ b/examples/plot_version_diff_surface.py
@@ -12,7 +12,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 
-from pymsis import msis
+import pymsis
 
 
 lons = range(-180, 185, 5)
@@ -25,8 +25,8 @@ ap = 7
 date = np.datetime64("2003-01-01T12:00")
 aps = [[ap] * 7]
 
-output2 = msis.run(date, lons, lats, alt, f107, f107a, aps)
-output0 = msis.run(date, lons, lats, alt, f107, f107a, aps, version=0)
+output2 = pymsis.calculate(date, lons, lats, alt, f107, f107a, aps)
+output0 = pymsis.calculate(date, lons, lats, alt, f107, f107a, aps, version=0)
 diff = (output2 - output0) / output0 * 100
 #  diff is now of the shape (1, nlons, nlats, 1, 11)
 # Get rid of the single dimensions
@@ -36,7 +36,7 @@ fig, axarr = plt.subplots(nrows=3, ncols=3, constrained_layout=True, figsize=(8,
 xx, yy = np.meshgrid(lons, lats)
 norm = mpl.colors.Normalize(-50, 50)
 cmap = mpl.colormaps["RdBu_r"]
-for i, variable in enumerate(msis.Variable):
+for i, variable in enumerate(pymsis.Variable):
     if i > 8:
         break
     ax = axarr.flatten()[i]

--- a/pymsis/__init__.py
+++ b/pymsis/__init__.py
@@ -2,5 +2,9 @@
 
 import importlib.metadata
 
+from pymsis.msis import Variable, calculate
+
 
 __version__ = importlib.metadata.version("pymsis")
+
+__all__ = ["__version__", "Variable", "calculate"]

--- a/pymsis/msis.py
+++ b/pymsis/msis.py
@@ -23,8 +23,8 @@ for lib in [msis00f, msis20f, msis21f]:
 
 
 class Variable(IntEnum):
-    """
-    Enumeration of output data indices for the pymsis run calls.
+    r"""
+    Enumeration of variable data indices for the output from ``calculate()``.
 
     This can be used to access the data from the output arrays instead of having
     to remember the order of the output. For example,
@@ -33,25 +33,25 @@ class Variable(IntEnum):
     Attributes
     ----------
     MASS_DENSITY
-        Index of total mass density (kg/m3).
+        Index of total mass density (kg/m\ :sup:`3`).
     N2
-        Index of N2 number density (m-3).
+        Index of N2 number density (m\ :sup:`-3`).
     O2
-        Index of O2 number density (m-3).
+        Index of O2 number density (m\ :sup:`-3`).
     O
-        Index of O number density (m-3).
+        Index of O number density (m\ :sup:`-3`).
     HE
-        Index of He number density (m-3).
+        Index of He number density (m\ :sup:`-3`).
     H
-        Index of H number density (m-3).
+        Index of H number density (m\ :sup:`-3`).
     AR
-        Index of Ar number density (m-3).
+        Index of Ar number density (m\ :sup:`-3`).
     N
-        Index of N number density (m-3).
+        Index of N number density (m\ :sup:`-3`).
     ANOMALOUS_O
-        Index of anomalous oxygen number density (m-3).
+        Index of anomalous oxygen number density (m\ :sup:`-3`).
     NO
-        Index of NO number density (m-3).
+        Index of NO number density (m\ :sup:`-3`).
     TEMPERATURE
         Index of temperature (K).
 
@@ -70,7 +70,7 @@ class Variable(IntEnum):
     TEMPERATURE = 10
 
 
-def run(
+def calculate(
     dates: npt.ArrayLike,
     lons: npt.ArrayLike,
     lats: npt.ArrayLike,
@@ -83,7 +83,7 @@ def run(
     version: float | str = 2.1,
     **kwargs: dict,
 ) -> npt.NDArray:
-    """
+    r"""
     Call MSIS to calculate the atmosphere at the provided input points.
 
     **Satellite Fly-Through Mode:**
@@ -136,23 +136,23 @@ def run(
         MSIS version number, one of (0, 2.0, 2.1).
     **kwargs : dict
         Single options for the switches can be defined through keyword arguments.
-        For example, run(..., geomagnetic_activity=-1) will set the geomagnetic
+        For example, calculate(..., geomagnetic_activity=-1) will set the geomagnetic
         activity switch to -1 (storm-time ap mode).
 
     Returns
     -------
     ndarray (ndates, nlons, nlats, nalts, 11) or (ndates, 11)
         | The data calculated at each grid point:
-        | [Total mass density (kg/m3),
-        | N2 # density (m-3),
-        | O2 # density (m-3),
-        | O # density (m-3),
-        | He # density (m-3),
-        | H # density (m-3),
-        | Ar # density (m-3),
-        | N # density (m-3),
-        | Anomalous oxygen # density (m-3),
-        | NO # density (m-3),
+        | [Total mass density (kg/m\ :sup:`3`),
+        | N2 # density (m\ :sup:`-3`),
+        | O2 # density (m\ :sup:`-3`),
+        | O # density (m\ :sup:`-3`),
+        | He # density (m\ :sup:`-3`),
+        | H # density (m\ :sup:`-3`),
+        | Ar # density (m\ :sup:`-3`),
+        | N # density (m\ :sup:`-3`),
+        | Anomalous oxygen # density (m\ :sup:`-3`),
+        | NO # density (m\ :sup:`-3`),
         | Temperature (K)]
 
     Other Parameters
@@ -246,6 +246,10 @@ def run(
     output[(output >= 9.9e-38) & (output < 1e-37)] = np.nan  # noqa: PLR2004
 
     return output.reshape(*input_shape, 11)
+
+
+# For backwards compatibility export the old name here
+run = calculate
 
 
 def create_options(

--- a/pymsis/utils.py
+++ b/pymsis/utils.py
@@ -22,13 +22,13 @@ def download_f107_ap() -> None:
     Download the latest ap and F10.7 values.
 
     The file is downloaded into the installed package location, keeping
-    the same filename as the data source: `SW-All.csv`.
+    the same filename as the data source: ``SW-All.csv``.
     This routine can be called to update the data as well if you would like to
     use newer data since the last time you downloaded the file.
 
     Notes
     -----
-    The data provider we are using is CelesTrak, which gets data from other
+    The default data provider is CelesTrak, which gets data from other
     sources and interpolates or predicts missing values to make data easier to
     work with. A warning is emitted when the interpolation or prediction
     occurs, but it is up to the user to verify the Ap and F10.7 data that is used
@@ -192,7 +192,7 @@ def get_f107_ap(dates: npt.ArrayLike) -> tuple[npt.NDArray, npt.NDArray, npt.NDA
         f107a : np.ndarray
             F10.7 running 81-day average centered on the given date(s)
         ap : np.ndarray
-            | Ap for the given date(s), (1-6 only used if `geomagnetic_activity=-1`)
+            | Ap for the given date(s), (1-6 only used if ``geomagnetic_activity=-1``)
             | (0) Daily Ap
             | (1) 3 hr ap index for current time
             | (2) 3 hr ap index for 3 hrs before current time

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import numpy as np
 from numpy.testing import assert_allclose
 
-from pymsis import msis
+import pymsis
 
 
 def run_input_line(line, version):
@@ -28,7 +28,7 @@ def run_input_line(line, version):
     )
 
     test_inp = (date, lon, lat, alt, f107, f107a, ap)
-    test_output = np.squeeze(msis.run(*test_inp, version=version))
+    test_output = np.squeeze(pymsis.calculate(*test_inp, version=version))
 
     # Rearrange the run's output to match the expected
     # ordering of elements


### PR DESCRIPTION
This changes the too-generic `run()` to `calculate()` instead and exports that to the pymsis top-level project so users don't have to do multiple submodule imports. `run()` is left for backwards compatibility for now, but not exported into the top-level namespace.

The examples have been updated to use the pattern:
```python
import pymsis

pymsis.calculate(...)
```