### PR TITLE
MNT: Change default optimization levels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,18 +8,14 @@ on:
     branches: [ 'main' ]
   pull_request:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
-  cancel-in-progress: true
-
 jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-            python-version: 3.11
+            python-version: 3.13
       - name: Install mypy
         run: |
           python -m pip install mypy numpy
@@ -35,7 +31,7 @@ jobs:
         shell: bash
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # sets up the compiler paths automatically for us
     - uses: fortran-lang/setup-fortran@v1
@@ -52,7 +48,7 @@ jobs:
         gfortran --version
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: Quansight-Labs/setup-python@b9ab292c751a42bcd2bb465b7fa202ea2c3f5796  # v5.3.1
+      uses: actions/setup-python@v5 
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -63,11 +59,7 @@ jobs:
     - name: Install pymsis
       run: |
         python -m pip install --upgrade pip
-        # TODO: Remove meson installation from source once a new release
-        # that includes https://github.com/mesonbuild/meson/pull/13851 is available
-        python -m pip install git+https://github.com/mesonbuild/meson
-        python -m pip install ninja meson-python setuptools_scm numpy
-        python -m pip install --no-build-isolation -v .[test]
+        python -m pip install -v .[test]
 
     - name: Test with pytest
       run: |

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,7 @@ project(
   license: 'MIT',
   meson_version: '>=1.2.99',
   default_options: [
+    'buildtype=release',
     'fortran_std=legacy',
   ],
 )
@@ -30,15 +31,18 @@ ff = meson.get_compiler('fortran')
 if ff.has_argument('-Wno-conversion')
   add_project_arguments('-Wno-conversion', language: 'fortran')
 endif
-
-# Default to optimization level 1
-# Some CI jobs fail with higher levels of optimization, so restrict this by default.
-add_project_arguments('-O1', language: 'fortran')
+if ff.has_argument('-ffast-math')
+  add_project_arguments('-ffast-math', language: 'fortran')
+endif
 
 is_windows = host_machine.system() == 'windows'
 # Platform detection
 is_mingw = is_windows and cc.get_id() == 'gcc'
 if is_windows
+  # Default to optimization level 0 on Windows only
+  # Some CI jobs fail with higher levels of optimization, so restrict this by default.
+  add_project_arguments('-O0', language: 'fortran')
+
   # Need static libraries to get libgfortran
   gcc_link_args = ['-static']
   if is_mingw


### PR DESCRIPTION
Don't optimize windows, increase optimization on linux/mac
* Add meson default `buildtype=release` (O3)
* Add `-ffast-math` flag if compiler supports it

## Profiling

Doing some quick timing examples locally to see what kind of difference this makes and it is larger than I expected, with ~3x difference. Windows friends, I'm sorry, perhaps someone with a Windows machine can debug how to fix the tests when we start including compiler optimizations.

### Example script

```python
import time

import numpy as np

from pymsis import msis


lons = np.arange(90)
lats = np.arange(37)
alts = np.arange(72) + 200
dates = np.datetime64("2010-01-01T00:00") + np.timedelta64(1, "h") * np.arange(6)

start = time.perf_counter()
for _ in range(20):
    output = msis.run(dates, lons, lats, alts)
end = time.perf_counter()
print("Time elapsed (20 calls): ", end - start)
```

### Results

| FFLAGS | Time (s) |
| ------------- | ------------- |
| -Ofast  | 8.16  |
| -O3  | 11.78  |
| -O2  | 12.34  |
| -O1  | 13.34  |
| -O0  | 23.5  |