### PR TITLE
PERF: Speed up create_input when dates are already np.datetime64

### DIFF
--- a/pymsis/msis.py
+++ b/pymsis/msis.py
@@ -377,15 +377,14 @@ def create_input(
         (ndates == nlons == nlats == nalts), then the shape is (ndates,).
     """
     # Turn everything into arrays
-    dates_arr: npt.NDArray[np.datetime64] = np.atleast_1d(
-        np.array(dates, dtype=np.datetime64)
-    )
-    dyear: npt.NDArray[np.datetime64] = (
-        dates_arr.astype("datetime64[D]") - dates_arr.astype("datetime64[Y]")
-    ).astype(float) + 1  # DOY 1-366
-    dseconds: npt.NDArray[np.datetime64] = (
-        dates_arr.astype("datetime64[s]") - dates_arr.astype("datetime64[D]")
-    ).astype(float)
+    dates_arr: npt.NDArray[np.datetime64] = np.atleast_1d(dates).astype(np.datetime64)
+    dates_arr_y = dates_arr.astype("datetime64[Y]")
+    dates_arr_d = dates_arr.astype("datetime64[D]")
+    dates_arr_s = dates_arr.astype("datetime64[s]")
+
+    # dyear is DOY 1-366
+    dyear: npt.NDArray[np.float64] = (dates_arr_d - dates_arr_y).astype(float) + 1.0
+    dseconds: npt.NDArray[np.float64] = (dates_arr_s - dates_arr_d).astype(float)
     # TODO: Make it a continuous day of year?
     #       The new code mentions it should be and accepts float, but the
     #       regression tests indicate it should still be integer DOY


### PR DESCRIPTION
In my workflow, about 65% of the pymsis runtime is spent in manipulating the python inputs rather than running the core code. This small change avoids some array creations and speeds up overall runtime by about 25% for me!

Before:
![image](https://github.com/user-attachments/assets/1b532dd7-209d-48bb-b15c-c67fc14fa565)

After:
![image](https://github.com/user-attachments/assets/d3c36ff4-a5e3-4093-90eb-8209a54d880a)
